### PR TITLE
Add bda skeleton

### DIFF
--- a/BDA3/README.md
+++ b/BDA3/README.md
@@ -1,0 +1,123 @@
+# Bayesian Data Analysis with Python and PyMC3
+
+[Bayesian Data Analysis](http://www.stat.columbia.edu/~gelman/book/) by Gelman, Carlin, Stern, Dunson, Vehtari, and Rubin is a comprehensive, standard, and wonderful textbook on Bayesian Methods.  There currently exist code for examples in the book in [R](https://github.com/avehtari/BDA_R_demos), [Python](https://github.com/avehtari/BDA_py_demos), and [Matlab](https://github.com/avehtari/BDA_m_demos), all using the [Stan](http://mc-stan.org/) language.
+
+This repository is a work in progress, organizing work on porting examples and exercises to Python and PyMC3. Please open a pull request on the README to indicate interest in a chapter or section!
+
+## Chapters
+
+1. Probability and Inference
+
+    Unclaimed
+
+1. Single-parameter models
+
+    Unclaimed
+
+1. Introduction to multiparameter models
+
+    Unclaimed
+
+1. Asymptotics and connections to non-Bayesian approaches
+
+    Unclaimed
+
+1. Hierarchical models
+
+    Unclaimed
+
+1. Model checking
+
+    Unclaimed
+
+1. Evaluating, comparing, and expanding models
+
+    Unclaimed
+
+1. Modeling accounting for data collection
+
+    Unclaimed
+
+1. Decision analysis
+
+    Unclaimed
+
+1. Introduction to Bayesian computation
+
+    Unclaimed
+
+1. Basics of Markov chain simulation
+
+    Unclaimed
+
+1. Computationally efficient Markov chain simulation
+
+    Unclaimed
+
+1. Modal and distributional approximations
+
+    Unclaimed
+
+1. Introduction to regression models
+
+    Unclaimed
+
+1. Hierarchical linear models
+
+    Unclaimed
+
+1. Generalized linear models
+
+    Unclaimed
+
+1. Models for robust inference
+
+    Unclaimed
+
+1. Models for missing data
+
+    Unclaimed
+
+1. Parametric nonlinear models
+
+    Unclaimed
+
+1. Basis function models
+
+    Unclaimed
+
+1. Gaussian process models
+
+    Unclaimed
+
+1. Finite mixture models
+
+    Unclaimed
+
+1. Dirichlet process models
+
+    Unclaimed
+
+
+## Contributing
+
+All contributions are welcome!
+
+Feel free to send PR to fix errors, improve the code or made comments that could help the user of this repository and readers of the book.
+
+## Installing the dependencies
+
+To install the dependencies to run these notebooks, you can use
+[Anaconda](https://www.continuum.io/downloads). Once you have installed
+Anaconda, run:
+
+    conda env create -f environment.yml
+
+to install all the dependencies into an isolated environment. You can switch to
+this environment by running:
+
+    source activate bda3-pymc3
+
+
+---
+<a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a><br /><span>Bayesian Data Analysis with Python and PyMC3</span> by <a xmlns:cc="http://creativecommons.org/ns#" href="https://github.com/pymc-devs/resources/graphs/contributors" property="cc:attributionName" rel="cc:attributionURL">All Contributors</a> is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.

--- a/BDA3/environment.yml
+++ b/BDA3/environment.yml
@@ -1,0 +1,8 @@
+name: bda3-pymc3
+channels:
+- defaults
+dependencies:
+  - jupyter
+  - seaborn
+  - pip:
+     - "git+git://github.com/pymc-devs/pymc3.git@master"


### PR DESCRIPTION
There's been discussion of porting examples from BDA3 to `PyMC3`.  This creates a framework for doing so.