### PR TITLE
Add mkl-service

### DIFF
--- a/BCM/environment.yml
+++ b/BCM/environment.yml
@@ -3,6 +3,7 @@ channels:
 - defaults
 dependencies:
   - jupyter
+  - mkl-service
   - seaborn
   - statsmodels
   - pip:

--- a/Rethinking/environment.yml
+++ b/Rethinking/environment.yml
@@ -3,6 +3,7 @@ channels:
 - defaults
 dependencies:
   - jupyter
+  - mkl-service
   - seaborn
   - statsmodels
   - pip:


### PR DESCRIPTION
Tried launching the Rethinking chapters on binderhub - it fails to import theano, and suggests `mkl-service`.