### PR TITLE
Add ArviZ to yml

### DIFF
--- a/Rethinking/environment.yml
+++ b/Rethinking/environment.yml
@@ -7,4 +7,5 @@ dependencies:
   - seaborn
   - statsmodels
   - pip:
+     - "git+git://github.com/arviz-devs/arviz.git@master"
      - "git+git://github.com/pymc-devs/pymc3.git@master"


### PR DESCRIPTION
Fix for 'arviz not installed' error when running a notebook. Great work by the way!