### PR TITLE
Fix softmax regressions chp10 NB

### DIFF
--- a/Rethinking/Chp_10.ipynb
+++ b/Rethinking/Chp_10.ipynb
@@ -6,24 +6,21 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import pymc3 as pm\n",
+    "import arviz as az\n",
+    "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
     "import pandas as pd\n",
+    "import pymc3 as pm\n",
+    "import seaborn as sns\n",
+    "import theano.tensor as tt\n",
+    "import warnings\n",
+    "\n",
     "from scipy import stats\n",
     "from scipy.special import expit as logistic\n",
-    "import seaborn as sns\n",
-    "import arviz as az\n",
-    "import matplotlib.pyplot as plt"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "\n",
     "%config InlineBackend.figure_format = 'retina'\n",
-    "az.style.use('arviz-darkgrid')"
+    "az.style.use('arviz-darkgrid')\n",
+    "warnings.simplefilter(action=\"ignore\", category=FutureWarning)"
    ]
   },
   {
@@ -4301,24 +4298,37 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 67,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([1, 0, 1, 2, 0, 1, 0, 1, 2, 2, 2])"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# simulate career choices among 500 individuals\n",
     "N = 500                 # number of individuals\n",
-    "income = np.arange(3)+1 # expected income of each career\n",
-    "score = 0.5*income      # scores for each career, based on income\n",
+    "income = np.arange(3) + 1 # expected income of each career\n",
+    "score = 0.5 * income      # scores for each career, based on income\n",
+    "\n",
     "# next line converts scores to probabilities\n",
     "def softmax(w):\n",
     "    e = np.exp(w)\n",
     "    return e/np.sum(e, axis=0)\n",
-    "\n",
     "p = softmax(score)\n",
+    "\n",
     "# now simulate choice\n",
     "# outcome career holds event type values, not counts\n",
     "career = np.random.multinomial(1, p, size=N)\n",
-    "career = np.where(career==1)[1]"
+    "career = np.where(career==1)[1]\n",
+    "career[:11]"
    ]
   },
   {
@@ -4330,38 +4340,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 68,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "/anaconda/envs/fund/lib/python3.7/site-packages/ipykernel_launcher.py:7: UserWarning: DEPRECATION: If x is a vector, Softmax will not automatically pad x anymore in next releases. If you need it, please do it manually. The vector case is gonna be supported soon and the output will be a vector.\n",
+      "  import sys\n",
       "Auto-assigning NUTS sampler...\n",
       "Initializing NUTS using jitter+adapt_diag...\n",
       "Multiprocess sampling (2 chains in 2 jobs)\n",
-      "NUTS: [b]\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "8efd89281a604221bc7aa0edb06868b4",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "HBox(children=(IntProgress(value=0, description='Sampling 2 chains', max=4000, style=ProgressStyle(description…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n"
+      "NUTS: [b]\n",
+      "Sampling 2 chains, 0 divergences: 100%|██████████| 6000/6000 [00:11<00:00, 530.57draws/s]\n"
      ]
     },
     {
@@ -4400,18 +4392,18 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>b</th>\n",
-       "      <td>0.7</td>\n",
-       "      <td>0.16</td>\n",
-       "      <td>0.44</td>\n",
-       "      <td>0.94</td>\n",
-       "      <td>0.01</td>\n",
+       "      <td>b</td>\n",
+       "      <td>0.33</td>\n",
+       "      <td>0.04</td>\n",
+       "      <td>0.27</td>\n",
+       "      <td>0.4</td>\n",
        "      <td>0.0</td>\n",
-       "      <td>857.52</td>\n",
-       "      <td>806.21</td>\n",
-       "      <td>906.66</td>\n",
-       "      <td>930.73</td>\n",
-       "      <td>1.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>615.94</td>\n",
+       "      <td>615.94</td>\n",
+       "      <td>623.48</td>\n",
+       "      <td>1125.77</td>\n",
+       "      <td>1.01</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -4419,13 +4411,13 @@
       ],
       "text/plain": [
        "   mean    sd  hpd_5.5%  hpd_94.5%  mcse_mean  mcse_sd  ess_mean  ess_sd  \\\n",
-       "b   0.7  0.16      0.44       0.94       0.01      0.0    857.52  806.21   \n",
+       "b  0.33  0.04      0.27        0.4        0.0      0.0    615.94  615.94   \n",
        "\n",
        "   ess_bulk  ess_tail  r_hat  \n",
-       "b    906.66    930.73    1.0  "
+       "b    623.48   1125.77   1.01  "
       ]
      },
-     "execution_count": 68,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4435,9 +4427,12 @@
     "    b = pm.Normal('b', 0., 5.)\n",
     "    s2 = b*2\n",
     "    s3 = b*3\n",
-    "    p_ = pm.math.stack([b, s2, s3])\n",
-    "    obs = pm.Categorical('career', p=pm.math.sigmoid(p_), observed=career)\n",
-    "    trace_10_16 = pm.sample(1000, tune=1000)\n",
+    "    \n",
+    "    p_ = pm.math.stack([0, s2, s3])\n",
+    "    obs = pm.Categorical('career', p=tt.nnet.softmax(p_), observed=career)\n",
+    "    \n",
+    "    trace_10_16 = pm.sample(1000, tune=2000, cores=2)\n",
+    "    \n",
     "az.summary(trace_10_16, credible_interval=.89, round_to=2)"
    ]
   },
@@ -4450,23 +4445,43 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 69,
+   "execution_count": 4,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([1, 2, 2, 2, 1, 2, 2, 2, 0, 2, 2, 2, 1, 2, 2, 2, 1, 2, 1, 2, 0, 2,\n",
+       "       2, 0, 2, 1, 2, 2, 2, 2, 1, 2, 2, 1, 2, 0, 2, 1, 2, 2, 2, 1, 2, 1,\n",
+       "       1, 2, 1, 2, 2, 1, 1, 1, 2, 2, 2, 1, 1, 2, 2, 2, 2, 1, 2, 0, 1, 2,\n",
+       "       2, 2, 2, 2, 2, 1, 0, 1, 1, 0, 2, 2, 0, 2, 2, 2, 2, 0, 2, 2, 2, 2,\n",
+       "       2, 1, 2, 1, 2, 2, 2, 2, 1, 2, 2, 0])"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "N = 100\n",
+    "\n",
     "# simulate family incomes for each individual\n",
     "family_income = np.random.rand(N)\n",
+    "\n",
     "# assign a unique coefficient for each type of event\n",
     "b = np.arange(3)-1\n",
+    "\n",
     "p = softmax(score[:, None] + np.outer(b, family_income)).T\n",
+    "\n",
     "career = np.asarray([np.random.multinomial(1, pp) for pp in p])\n",
-    "career = np.where(career==1)[1]"
+    "career = np.where(career==1)[1]\n",
+    "career"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 70,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -4476,35 +4491,8 @@
       "Auto-assigning NUTS sampler...\n",
       "Initializing NUTS using jitter+adapt_diag...\n",
       "Multiprocess sampling (2 chains in 2 jobs)\n",
-      "NUTS: [b23, a23]\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ff6f4003b5e34aca926d4dfc6cbe8281",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "HBox(children=(IntProgress(value=0, description='Sampling 2 chains', max=4000, style=ProgressStyle(description…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "The number of effective samples is smaller than 25% for some parameters.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n"
+      "NUTS: [b23, a23]\n",
+      "Sampling 2 chains, 0 divergences: 100%|██████████| 6000/6000 [00:38<00:00, 157.53draws/s]\n"
      ]
     },
     {
@@ -4543,60 +4531,60 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>a23[0]</th>\n",
-       "      <td>0.54</td>\n",
-       "      <td>0.07</td>\n",
-       "      <td>0.43</td>\n",
-       "      <td>0.67</td>\n",
-       "      <td>0.00</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>561.22</td>\n",
-       "      <td>561.22</td>\n",
-       "      <td>563.73</td>\n",
-       "      <td>693.97</td>\n",
-       "      <td>1.00</td>\n",
+       "      <td>a23[0]</td>\n",
+       "      <td>0.87</td>\n",
+       "      <td>0.76</td>\n",
+       "      <td>-0.37</td>\n",
+       "      <td>2.03</td>\n",
+       "      <td>0.03</td>\n",
+       "      <td>0.02</td>\n",
+       "      <td>555.77</td>\n",
+       "      <td>555.77</td>\n",
+       "      <td>557.28</td>\n",
+       "      <td>788.43</td>\n",
+       "      <td>1.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>a23[1]</th>\n",
-       "      <td>1.85</td>\n",
-       "      <td>0.06</td>\n",
+       "      <td>a23[1]</td>\n",
        "      <td>1.76</td>\n",
-       "      <td>1.96</td>\n",
-       "      <td>0.00</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>563.97</td>\n",
-       "      <td>563.97</td>\n",
-       "      <td>561.25</td>\n",
-       "      <td>595.11</td>\n",
-       "      <td>1.00</td>\n",
+       "      <td>0.68</td>\n",
+       "      <td>0.70</td>\n",
+       "      <td>2.86</td>\n",
+       "      <td>0.03</td>\n",
+       "      <td>0.02</td>\n",
+       "      <td>549.78</td>\n",
+       "      <td>527.32</td>\n",
+       "      <td>557.30</td>\n",
+       "      <td>691.57</td>\n",
+       "      <td>1.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>b23[0]</th>\n",
-       "      <td>0.01</td>\n",
-       "      <td>0.12</td>\n",
-       "      <td>-0.19</td>\n",
-       "      <td>0.20</td>\n",
-       "      <td>0.01</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>515.55</td>\n",
-       "      <td>515.55</td>\n",
-       "      <td>519.79</td>\n",
-       "      <td>783.58</td>\n",
-       "      <td>1.01</td>\n",
+       "      <td>b23[0]</td>\n",
+       "      <td>0.27</td>\n",
+       "      <td>1.27</td>\n",
+       "      <td>-1.99</td>\n",
+       "      <td>2.07</td>\n",
+       "      <td>0.05</td>\n",
+       "      <td>0.04</td>\n",
+       "      <td>569.73</td>\n",
+       "      <td>569.73</td>\n",
+       "      <td>570.80</td>\n",
+       "      <td>842.66</td>\n",
+       "      <td>1.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>b23[1]</th>\n",
-       "      <td>0.00</td>\n",
-       "      <td>0.11</td>\n",
-       "      <td>-0.16</td>\n",
-       "      <td>0.18</td>\n",
-       "      <td>0.00</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>537.41</td>\n",
-       "      <td>537.41</td>\n",
-       "      <td>540.44</td>\n",
-       "      <td>729.27</td>\n",
-       "      <td>1.01</td>\n",
+       "      <td>b23[1]</td>\n",
+       "      <td>0.34</td>\n",
+       "      <td>1.15</td>\n",
+       "      <td>-1.32</td>\n",
+       "      <td>2.29</td>\n",
+       "      <td>0.05</td>\n",
+       "      <td>0.03</td>\n",
+       "      <td>560.08</td>\n",
+       "      <td>560.08</td>\n",
+       "      <td>557.17</td>\n",
+       "      <td>834.00</td>\n",
+       "      <td>1.0</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -4604,32 +4592,36 @@
       ],
       "text/plain": [
        "        mean    sd  hpd_5.5%  hpd_94.5%  mcse_mean  mcse_sd  ess_mean  ess_sd  \\\n",
-       "a23[0]  0.54  0.07      0.43       0.67       0.00      0.0    561.22  561.22   \n",
-       "a23[1]  1.85  0.06      1.76       1.96       0.00      0.0    563.97  563.97   \n",
-       "b23[0]  0.01  0.12     -0.19       0.20       0.01      0.0    515.55  515.55   \n",
-       "b23[1]  0.00  0.11     -0.16       0.18       0.00      0.0    537.41  537.41   \n",
+       "a23[0]  0.87  0.76     -0.37       2.03       0.03     0.02    555.77  555.77   \n",
+       "a23[1]  1.76  0.68      0.70       2.86       0.03     0.02    549.78  527.32   \n",
+       "b23[0]  0.27  1.27     -1.99       2.07       0.05     0.04    569.73  569.73   \n",
+       "b23[1]  0.34  1.15     -1.32       2.29       0.05     0.03    560.08  560.08   \n",
        "\n",
        "        ess_bulk  ess_tail  r_hat  \n",
-       "a23[0]    563.73    693.97   1.00  \n",
-       "a23[1]    561.25    595.11   1.00  \n",
-       "b23[0]    519.79    783.58   1.01  \n",
-       "b23[1]    540.44    729.27   1.01  "
+       "a23[0]    557.28    788.43    1.0  \n",
+       "a23[1]    557.30    691.57    1.0  \n",
+       "b23[0]    570.80    842.66    1.0  \n",
+       "b23[1]    557.17    834.00    1.0  "
       ]
      },
-     "execution_count": 70,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "with pm.Model() as m_10_17:\n",
-    "    a23 = pm.Normal('a23', 0, 5, shape=2)\n",
-    "    b23 = pm.Normal('b23', 0, 5, shape=2)\n",
+    "    a23 = pm.Normal('a23', 0., 5., shape=2)\n",
+    "    b23 = pm.Normal('b23', 0., 5., shape=2)\n",
+    "    \n",
     "    s2 = a23[0] + b23[0]*family_income\n",
     "    s3 = a23[1] + b23[1]*family_income\n",
+    "    \n",
     "    p_ = pm.math.stack([np.zeros(N), s2, s3]).T\n",
-    "    obs = pm.Categorical('career', p=pm.math.sigmoid(p_), observed=career)\n",
-    "    trace_10_17 = pm.sample(1000, tune=1000)\n",
+    "    obs = pm.Categorical('career', p=tt.nnet.softmax(p_), observed=career)\n",
+    "    \n",
+    "    trace_10_17 = pm.sample(1000, tune=2000, cores=2)\n",
+    "    \n",
     "az.summary(trace_10_17, credible_interval=.89, round_to=2)"
    ]
   },
@@ -4968,9 +4960,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "fund",
    "language": "python",
-   "name": "python3"
+   "name": "fund"
   },
   "language_info": {
    "codemirror_mode": {
@@ -4982,9 +4974,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
As discussed in #59 this fixes the implementation of softmax regressions in chp 10 NB - they were over-parametrized and didn't use softmax as the link function.

_NB1_: I only ran the needed cells, not the whole NB

_NB2_: inference about the parameters doesn't seem very good - I suspect it comes from not-enough-regularizing priors, but I didn't change them to keep the book's parametrization

I'm here if updates are needed! PyMCheers 🖖 