### PR TITLE
updating install link for arviz changing from master to main branch

### DIFF
--- a/Rethinking_2/environment.yml
+++ b/Rethinking_2/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - pip
   - pip:
      - watermark
-     - "git+git://github.com/arviz-devs/arviz.git@master"
+     - "git+git://github.com/arviz-devs/arviz.git@main"
      - "git+git://github.com/pymc-devs/pymc3.git@master"
      - causalgraphicalmodels
      - daft


### PR DESCRIPTION
Arviz changed the name of their "master" branch to "main" branch. This broke the environment.yml file. Updating the install link is all that is required to fix this. 