### PR TITLE
az.hpd has been removed

### DIFF
--- a/Rethinking_2/environment.yml
+++ b/Rethinking_2/environment.yml
@@ -3,6 +3,7 @@ channels:
 - defaults
 dependencies:
   - jupyter
+  - seaborn
   - mkl-service
   - pip
   - pip:


### PR DESCRIPTION
It looks like the current main branch of arviz has removed the hpd function.

Replace az.hpd with az.hdi

Add seaborn to environments.yml

