### PR TITLE
Fix readme and environment

### DIFF
--- a/Rethinking/README.md
+++ b/Rethinking/README.md
@@ -27,8 +27,21 @@ Anaconda, run:
 to install all the dependencies into an isolated environment. You can switch to
 this environment by running:
 
-    source activate stat-rethink-pymc3
+    source activate pymc3
+    
+To use the notebooks you first have to register your new environment as a valid notebook kernel:
 
+    python -m ipykernel install --user --name pymc3 --display-name "Python 3.9 (pymc3)"
+
+You can start a notebook by running:
+    
+    jupyter notebook
+
+or use the more modern jupyter lab:
+    
+    jupyter lab
+    
+from the root directory.
 
 ---
 

--- a/Rethinking/environment.yml
+++ b/Rethinking/environment.yml
@@ -1,10 +1,14 @@
-name: stat-rethink-pymc3
+name: pymc3
 channels:
-- defaults
+- conda-forge
 dependencies:
+  - python=3.9
   - jupyter
+  - jupyterlab
   - mkl-service
   - seaborn
   - statsmodels
-  - pip:
-     - "git+git://github.com/pymc-devs/pymc3.git@master"
+  - pymc3
+  - theano-pymc
+  - mkl
+  - mkl-service


### PR DESCRIPTION
# Thank you for opening a pull request!

Please check our [style guide](https://docs.pymc.io/en/latest/contributing/jupyter_style.html), and also make sure that the notebooks you've modified pass the `pre-commit` checks. If, for example, you modified `notebook1.ipynb` and `notebook2.ipynb`, you could do this by running:

```bash
pre-commit run --files notebook1.ipynb notebook2.ipynb
```

You may need to run it a couple of times before all the checks pass.

I noticed that the installation throw errors because the github link no longer works (wrong branch and we don't want to install the beta anyway), so I switched to normal pypi dependency for pymc3 and added jupyter lab as the more modern notebook environment. I also added critical instructions to the readme how to actually install the kernels required to start the notebooks
