### PR TITLE
Update README.md branch name links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 PyMC3 educational resources, including the PyMC3 port of the following books (original models in STAN/BUGS/JAGS etc,.):
 
 -  ["Bayesian Modeling and Computation in Python" by Osvaldo A. Martin,  Ravin Kumar, Junpeng Lao](https://bayesiancomputationbook.com/welcome.html)
--  [PyMC3 port of the book "Statistical Rethinking" by Richard McElreath (first edition)](https://github.com/pymc-devs/resources/tree/master/Rethinking)
--  [PyMC3 port of the book "Statistical Rethinking" by Richard McElreath (second edition)](https://github.com/pymc-devs/resources/tree/master/Rethinking_2)
--  [PyMC3 port of the book "Bayesian Cognitive Modeling" by Michael Lee and EJ Wagenmakers](https://github.com/pymc-devs/resources/tree/master/BCM)
--  [PyMC3 port of the book "Bayesian Statistical Methods" by Brian J. Reich and Sujit K. Ghosh](https://github.com/pymc-devs/resources/tree/master/BSM)
--  [PyMC3 port of the book "Bayesian Data Analysis" by Andrew Gelman, John B. Carlin, Hal S. Stern, David B. Dunson, Aki Vehtari and Donald B. Rubin](https://github.com/pymc-devs/resources/tree/master/BDA3)
+-  [PyMC3 port of the book "Statistical Rethinking" by Richard McElreath (first edition)](https://github.com/pymc-devs/resources/tree/main/Rethinking)
+-  [PyMC3 port of the book "Statistical Rethinking" by Richard McElreath (second edition)](https://github.com/pymc-devs/resources/tree/main/Rethinking_2)
+-  [PyMC3 port of the book "Bayesian Cognitive Modeling" by Michael Lee and EJ Wagenmakers](https://github.com/pymc-devs/resources/tree/main/BCM)
+-  [PyMC3 port of the book "Bayesian Statistical Methods" by Brian J. Reich and Sujit K. Ghosh](https://github.com/pymc-devs/resources/tree/main/BSM)
+-  [PyMC3 port of the book "Bayesian Data Analysis" by Andrew Gelman, John B. Carlin, Hal S. Stern, David B. Dunson, Aki Vehtari and Donald B. Rubin](https://github.com/pymc-devs/resources/tree/main/BDA3)
 
 
 # License


### PR DESCRIPTION
Renaming default branch main for links as well, even though they still redirect might as well get it right
